### PR TITLE
08: trpc setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,8 +38,13 @@
         "@radix-ui/react-toggle": "^1.1.9",
         "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
+        "@tanstack/react-query": "^5.76.1",
+        "@trpc/client": "^11.1.2",
+        "@trpc/server": "^11.1.2",
+        "@trpc/tanstack-react-query": "^11.1.2",
         "better-auth": "^1.2.9",
         "class-variance-authority": "^0.7.1",
+        "client-only": "^0.0.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
@@ -57,11 +62,12 @@
         "react-icons": "^5.5.0",
         "react-resizable-panels": "^3.0.2",
         "recharts": "^2.15.3",
+        "server-only": "^0.0.1",
         "sonner": "^2.0.5",
         "tailwind-merge": "^3.3.0",
         "vaul": "^1.1.2",
         "ws": "^8.18.2",
-        "zod": "^3.25.57"
+        "zod": "^3.25.7"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -4142,6 +4148,74 @@
         "@tailwindcss/oxide": "4.1.8",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.8"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.76.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.76.0.tgz",
+      "integrity": "sha512-FN375hb8ctzfNAlex5gHI6+WDXTNpe0nbxp/d2YJtnP+IBM6OUm7zcaoCW6T63BawGOYZBbKC0iPvr41TteNVg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.76.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.76.1.tgz",
+      "integrity": "sha512-YxdLZVGN4QkT5YT1HKZQWiIlcgauIXEIsMOTSjvyD5wLYK8YVvKZUPAysMqossFJJfDpJW3pFn7WNZuPOqq+fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.76.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@trpc/client": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@trpc/client/-/client-11.1.2.tgz",
+      "integrity": "sha512-RpifJOAv+ql9gF3oafa3dLCF01AzWu2DzejvehAPG2IlwHxopKoYXaImJ8zPwRkZokuWiKz5v65HjElmi8TlrQ==",
+      "funding": [
+        "https://trpc.io/sponsor"
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@trpc/server": "11.1.2",
+        "typescript": ">=5.7.2"
+      }
+    },
+    "node_modules/@trpc/server": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@trpc/server/-/server-11.1.2.tgz",
+      "integrity": "sha512-Oi9zWHG0ZDkbDo4sYkduoV7q4sIe6UwjrRLC91vNMYQK+PVgpbTCmK1laRwewAGu0zaayqcGDosANjceOIC3GA==",
+      "funding": [
+        "https://trpc.io/sponsor"
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5.7.2"
+      }
+    },
+    "node_modules/@trpc/tanstack-react-query": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@trpc/tanstack-react-query/-/tanstack-react-query-11.1.2.tgz",
+      "integrity": "sha512-c+NupnmIQmwgwYVTaHgDg59BZBtJ6KxqB0cxF9FBhKHPY6PlwGLdU8+mo25C5VIpofZYEII4H7NKE4yKGFSe3w==",
+      "funding": [
+        "https://trpc.io/sponsor"
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.67.1",
+        "@trpc/client": "11.1.2",
+        "@trpc/server": "11.1.2",
+        "react": ">=18.2.0",
+        "react-dom": ">=18.2.0",
+        "typescript": ">=5.7.2"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -9124,6 +9198,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
@@ -10189,9 +10269,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.57",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.57.tgz",
-      "integrity": "sha512-6tgzLuwVST5oLUxXTmBqoinKMd3JeesgbgseXeFasKKj8Q1FCZrHnbqJOyiEvr4cVAlbug+CgIsmJ8cl/pU5FA==",
+      "version": "3.25.7",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.7.tgz",
+      "integrity": "sha512-YGdT1cVRmKkOg6Sq7vY7IkxdphySKnXhaUmFI4r4FcuFVNgpCb9tZfNwXbT6BPjD5oz0nubFsoo9pIqKrDcCvg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -41,8 +41,13 @@
     "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",
+    "@tanstack/react-query": "^5.76.1",
+    "@trpc/client": "^11.1.2",
+    "@trpc/server": "^11.1.2",
+    "@trpc/tanstack-react-query": "^11.1.2",
     "better-auth": "^1.2.9",
     "class-variance-authority": "^0.7.1",
+    "client-only": "^0.0.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
@@ -60,11 +65,12 @@
     "react-icons": "^5.5.0",
     "react-resizable-panels": "^3.0.2",
     "recharts": "^2.15.3",
+    "server-only": "^0.0.1",
     "sonner": "^2.0.5",
     "tailwind-merge": "^3.3.0",
     "vaul": "^1.1.2",
     "ws": "^8.18.2",
-    "zod": "^3.25.57"
+    "zod": "^3.25.7"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -2,8 +2,11 @@ import { auth } from "@/lib/auth";
 import { headers } from "next/headers";
 import HomeView from "@/modules/home/ui/views/home-view";
 import { redirect } from "next/navigation";
+import { caller } from "@/trpc/server";
 
 const Page = async () => {
+  const data = await caller.hello({ text: "Stalin Server" });
+
   const session = await auth.api.getSession({
     headers: await headers(),
   });
@@ -11,7 +14,11 @@ const Page = async () => {
   if (!session) {
     redirect("/sign-in");
   }
-
+  return (
+    <div>
+      <p>{data?.greeting}</p>
+    </div>
+  );
   return <HomeView />;
 };
 

--- a/src/app/api/trpc/[trpc]/route.ts
+++ b/src/app/api/trpc/[trpc]/route.ts
@@ -1,0 +1,11 @@
+import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
+import { createTRPCContext } from "@/trpc/init";
+import { appRouter } from "@/trpc/routers/_app";
+const handler = (req: Request) =>
+  fetchRequestHandler({
+    endpoint: "/api/trpc",
+    req,
+    router: appRouter,
+    createContext: createTRPCContext,
+  });
+export { handler as GET, handler as POST };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
+import { TRPCReactProvider } from "@/trpc/client";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -17,10 +18,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body className={`${inter.className} ${inter.className} antialiased`}>
-        {children}
-      </body>
-    </html>
+    <TRPCReactProvider>
+      <html lang="en">
+        <body className={`${inter.className} ${inter.className} antialiased`}>
+          {children}
+        </body>
+      </html>
+    </TRPCReactProvider>
   );
 }

--- a/src/modules/home/ui/views/home-view.tsx
+++ b/src/modules/home/ui/views/home-view.tsx
@@ -1,35 +1,20 @@
 "use client";
-import { authClient } from "@/lib/auth-client";
-import { useRouter } from "next/navigation";
+
+import { useTRPC } from "@/trpc/client";
+import { useQuery } from "@tanstack/react-query";
 
 export default function HomeView() {
-  const { data: session } = authClient.useSession();
-  const router = useRouter();
-  const { signOut } = authClient;
-
-  if (!session) {
-    return <p>Loading...</p>;
-  }
-
-  if (session) {
-    return (
-      <div className="flex flex-col p-4 gap-y-4">
-        <h1>Logged in as {session?.user?.name}</h1>
-        <button
-          className="p-2 bg-primary rounded-xl border-1  text-white"
-          onClick={() =>
-            signOut({
-              fetchOptions: {
-                onSuccess: () => {
-                  router.push("/sign-in"); // redirect to login page
-                },
-              },
-            })
-          }
-        >
-          Logout
-        </button>
-      </div>
-    );
-  }
+  const trpc = useTRPC();
+  const { data: helloData } = useQuery(
+    trpc.hello.queryOptions({ text: "Stalin" })
+  );
+  const { data: gdbyData } = useQuery(
+    trpc.goodbye.queryOptions({ text: "Milan" })
+  );
+  return (
+    <div className="flex flex-col p-4 gap-y-4">
+      <div>{helloData?.greeting}</div>
+      <div>{gdbyData?.farewell}</div>
+    </div>
+  );
 }

--- a/src/trpc/client.tsx
+++ b/src/trpc/client.tsx
@@ -1,0 +1,49 @@
+"use client";
+// ^-- to make sure we can mount the Provider from a server component
+import type { QueryClient } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { createTRPCClient, httpBatchLink } from "@trpc/client";
+import { createTRPCContext } from "@trpc/tanstack-react-query";
+import { useState } from "react";
+import { makeQueryClient } from "./query-client";
+import type { AppRouter } from "./routers/_app";
+export const { TRPCProvider, useTRPC } = createTRPCContext<AppRouter>();
+let browserQueryClient: QueryClient;
+function getQueryClient() {
+  if (typeof window === "undefined") {
+    return makeQueryClient();
+  }
+  if (!browserQueryClient) browserQueryClient = makeQueryClient();
+  return browserQueryClient;
+}
+function getUrl() {
+  const base = (() => {
+    if (typeof window !== "undefined") return "";
+    return process.env.NEXT_PUBLIC_APP_URL;
+  })();
+  return `${base}/api/trpc`;
+}
+export function TRPCReactProvider(
+  props: Readonly<{
+    children: React.ReactNode;
+  }>
+) {
+  const queryClient = getQueryClient();
+  const [trpcClient] = useState(() =>
+    createTRPCClient<AppRouter>({
+      links: [
+        httpBatchLink({
+          // transformer: superjson, <-- if you use a data transformer
+          url: getUrl(),
+        }),
+      ],
+    })
+  );
+  return (
+    <QueryClientProvider client={queryClient}>
+      <TRPCProvider trpcClient={trpcClient} queryClient={queryClient}>
+        {props.children}
+      </TRPCProvider>
+    </QueryClientProvider>
+  );
+}

--- a/src/trpc/init.ts
+++ b/src/trpc/init.ts
@@ -1,0 +1,22 @@
+import { initTRPC } from "@trpc/server";
+import { cache } from "react";
+export const createTRPCContext = cache(async () => {
+  /**
+   * @see: https://trpc.io/docs/server/context
+   */
+  return { userId: "user_123" };
+});
+// Avoid exporting the entire t-object
+// since it's not very descriptive.
+// For instance, the use of a t variable
+// is common in i18n libraries.
+const t = initTRPC.create({
+  /**
+   * @see https://trpc.io/docs/server/data-transformers
+   */
+  // transformer: superjson,
+});
+// Base router and procedure helpers
+export const createTRPCRouter = t.router;
+export const createCallerFactory = t.createCallerFactory;
+export const baseProcedure = t.procedure;

--- a/src/trpc/query-client.ts
+++ b/src/trpc/query-client.ts
@@ -1,0 +1,23 @@
+import {
+  defaultShouldDehydrateQuery,
+  QueryClient,
+} from "@tanstack/react-query";
+// import superjson from "superjson";
+export function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 30 * 1000,
+      },
+      dehydrate: {
+        // serializeData: superjson.serialize,
+        shouldDehydrateQuery: (query) =>
+          defaultShouldDehydrateQuery(query) ||
+          query.state.status === "pending",
+      },
+      hydrate: {
+        // deserializeData: superjson.deserialize,
+      },
+    },
+  });
+}

--- a/src/trpc/routers/_app.ts
+++ b/src/trpc/routers/_app.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+import { baseProcedure, createTRPCRouter } from "../init";
+export const appRouter = createTRPCRouter({
+  hello: baseProcedure
+    .input(
+      z.object({
+        text: z.string(),
+      })
+    )
+    .query((opts) => {
+      return {
+        greeting: `hello ${opts.input.text}`,
+      };
+    }),
+  goodbye: baseProcedure.input(z.object({ text: z.string() })).query((opts) => {
+    return {
+      farewell: `goodbye ${opts.input.text}`,
+    };
+  }),
+});
+// export type definition of API
+export type AppRouter = typeof appRouter;

--- a/src/trpc/server.tsx
+++ b/src/trpc/server.tsx
@@ -1,0 +1,16 @@
+import "server-only"; // <-- ensure this file cannot be imported from the client
+import { createTRPCOptionsProxy } from "@trpc/tanstack-react-query";
+import { cache } from "react";
+import { createTRPCContext } from "./init";
+import { makeQueryClient } from "./query-client";
+import { appRouter } from "./routers/_app";
+// IMPORTANT: Create a stable getter for the query client that
+//            will return the same client during the same request.
+export const getQueryClient = cache(makeQueryClient);
+export const trpc = createTRPCOptionsProxy({
+  ctx: createTRPCContext,
+  router: appRouter,
+  queryClient: getQueryClient,
+});
+// ...
+export const caller = appRouter.createCaller(createTRPCContext);


### PR DESCRIPTION
Title: Add tRPC setup with React Query integration

Description:
This PR introduces tRPC with React Query for type-safe API calls. Key changes include:

Added tRPC dependencies (@trpc/* packages and @tanstack/react-query)

Implemented tRPC client and server setup:

Created tRPC context and router structure

Added API route handler (/api/trpc/[trpc])

Set up React Query provider

Added example procedures (hello and goodbye)

Updated home page to demonstrate tRPC usage

Added server/client boundary utilities (server-only, client-only)

The implementation provides:

Full-stack TypeScript type safety

React Query integration for data fetching

Proper server/client separation

Example queries demonstrating basic usage

Testing:

Verify hello and goodbye queries work in the home view

Confirm type safety between frontend and backend

Check server-side rendering behavior

Notes:

This sets up the foundation for future API endpoints

The home view currently shows simple examples that can be expanded later

Error handling and more complex queries can be added as needed